### PR TITLE
Make CONTAINER_NUMBER configurable and support multiple containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Een sensor component voor het ophalen (scrapen) van informatie van https://inzam
 Handleiding:
 - Voeg toe aan Home Assistant, via HACS of handmatig
 - Zoek je container nummer op op https://inzameling.spaarnelanden.nl/ en vul deze in tussen de quotes achter CONTAINER_NUMBER in sensor.py
-- Zet de volgende regels in je in de Home Assistant yaml file, onder `sensors:`
+- Zet de volgende regels in je Home Assistant yaml configuratie bestand, onder `sensors:`
 ~~~
 - platform: spaarnelanden_inzameling
   containers:
@@ -12,7 +12,7 @@ Handleiding:
 
 Opmerkingen:
 - Dit is het eerste en enige wat ik ooit in elkaar heb geklust in Python. *Alle verbeteringen zijn welkom, deel ze hier met mij!*
-- In condifuratie staat een container nummer, dit is het nummer wat je kunt vinden als 'Nummer' van jouw container op https://inzameling.spaarnelanden.nl/
+- In de yaml configuratie staat een container nummer, dit is het nummer wat je kunt vinden als 'Nummer' van jouw container op https://inzameling.spaarnelanden.nl/
 - De webpagina die wordt opgehaald is groot (10MB ongeveer dacht ik?), doe het niet te vaak. De variabele TIME_BETWEEN_UPDATES bewaakt dit, en staat op 10 minuten.
 
 Known issues:

--- a/README.md
+++ b/README.md
@@ -3,16 +3,20 @@ Een sensor component voor het ophalen (scrapen) van informatie van https://inzam
 Handleiding:
 - Voeg toe aan Home Assistant, via HACS of handmatig
 - Zoek je container nummer op op https://inzameling.spaarnelanden.nl/ en vul deze in tussen de quotes achter CONTAINER_NUMBER in sensor.py
-- Zet `- platform: spaarnelanden_inzameling` in de Home Assistant sensor.yaml file.
+- Zet de volgende regels in je in de Home Assistant yaml file, onder `sensors:`
+~~~
+- platform: spaarnelanden_inzameling
+  containers:
+  - 12345
+~~~
 
 Opmerkingen:
 - Dit is het eerste en enige wat ik ooit in elkaar heb geklust in Python. *Alle verbeteringen zijn welkom, deel ze hier met mij!*
-- In sensor.py staat een variabele CONTAINER_NUMBER, dit is het nummer wat je kunt vinden als 'Nummer' van jouw container op https://inzameling.spaarnelanden.nl/
+- In condifuratie staat een container nummer, dit is het nummer wat je kunt vinden als 'Nummer' van jouw container op https://inzameling.spaarnelanden.nl/
 - De webpagina die wordt opgehaald is groot (10MB ongeveer dacht ik?), doe het niet te vaak. De variabele TIME_BETWEEN_UPDATES bewaakt dit, en staat op 10 minuten.
 
 Known issues:
 - Als Home Assistant start, is er nog geen info van de sensor en staat deze op 'Unknown'. 
-- Configuratie gaat in de sensor.py file, niet via de Home Assistant configuratie.
 - Alleen getest met mijn eigen ondergrondse restafval-container.
 
 

--- a/custom_components/spaarnelanden_inzameling/sensor.py
+++ b/custom_components/spaarnelanden_inzameling/sensor.py
@@ -32,9 +32,10 @@ TRASH_TYPES = {
 }
 
 FILLING_DEGREE_STATUSES = {
-    1: 'Niet ingepland vandaag',
+    0: 'Niet ingepland vandaag',
+    1: 'Ingepland',
     2: 'Onbekend (2)',
-    3: 'Ingepland'
+    3: 'Niet ingepland vandaag',
 }
 
 _LOGGER = logging.getLogger(__name__)
@@ -60,7 +61,7 @@ def get_containerdata(container_number):
 
         for i in containers_json_decoded:
             if i['sRegistrationNumber'] == str(container_number):
-                containers_dictionary['filling_degree_status'] = FILLING_DEGREE_STATUSES[(i['iFillingDegreeStatus'])]
+                containers_dictionary['filling_degree_status'] = FILLING_DEGREE_STATUSES[(i['oPlanningDetail']['iPlanningActionStatus'])]
                 containers_dictionary['filling_degree'] = (i['dFillingDegree'])
                 containers_dictionary['latitude'] = (i['dLatitude'])
                 containers_dictionary['longitude'] = (i['dLongitude'])

--- a/custom_components/spaarnelanden_inzameling/sensor.py
+++ b/custom_components/spaarnelanden_inzameling/sensor.py
@@ -32,9 +32,9 @@ TRASH_TYPES = {
 }
 
 FILLING_DEGREE_STATUSES = {
-    0: 'Niet ingepland vandaag',
-    1: 'Ingepland',
-    2: 'Onbekend (2)',
+    0: 'Container wordt geleegd',
+    1: 'Geleegd',
+    2: 'Niet bereikbaar',
     3: 'Niet ingepland vandaag',
 }
 
@@ -61,7 +61,7 @@ def get_containerdata(container_number):
 
         for i in containers_json_decoded:
             if i['sRegistrationNumber'] == str(container_number):
-                containers_dictionary['filling_degree_status'] = FILLING_DEGREE_STATUSES[(i['oPlanningDetail']['iPlanningActionStatus'])]
+                containers_dictionary['filling_degree_status'] = i['oPlanningDetail']['iPlanningActionStatus'] > 0 and FILLING_DEGREE_STATUSES[(i['oPlanningDetail']['iPlanningActionStatus'])] or i['oPlanningDetail']['iInitialStatus'] == 3 and FILLING_DEGREE_STATUSES[(i['oPlanningDetail']['iPlanningActionStatus'])] or FILLING_DEGREE_STATUSES[(3)]
                 containers_dictionary['filling_degree'] = (i['dFillingDegree'])
                 containers_dictionary['latitude'] = (i['dLatitude'])
                 containers_dictionary['longitude'] = (i['dLongitude'])


### PR DESCRIPTION
Thanks for the base scripts of this plugin. I'm using this myself currently because i have some containers in front of my house and i would like to be notified if they come to pick it up in the morning when i have the same morning off from work.

This PR fixes a couple QOL issues that i came across when using it:
- Set a unique id for every container entry. This makes the entity manageable via Home Assistant so custom icons and names can be assigned.
- The CONTAINER_NUMBER can now be configured via the yaml file, so it is easier to configure the container
- Via the yaml configuration it is possible to also add multiple containers. In this case i have 5 containers in the neighbourhood (2x rest, 1x paper, 1x pmd and 1x glass)
- The filling_degree_status attribute now reflects the correct status. The status seemed to be off and i used the same logic as the website uses.
- Updated the README to reflect the new changes :)